### PR TITLE
Fix ROS camera not seeing the link color change

### DIFF
--- a/gazebo_domain_randomizer/nodes/link_visual_properties_randomizer
+++ b/gazebo_domain_randomizer/nodes/link_visual_properties_randomizer
@@ -4,6 +4,7 @@ import rospy
 from std_msgs.msg import ColorRGBA
 from gazebo_ext_msgs.srv import GetVisualNames, GetVisualNamesRequest
 from gazebo_ext_msgs.srv import SetLinkVisualProperties, SetLinkVisualPropertiesRequest
+from gazebo_ext_msgs.srv import SetLinkColor, SetLinkColorRequest
 from gazebo_domain_randomizer import utils
 
 class LinkVisualPropertiesRandomizer:
@@ -21,13 +22,16 @@ class LinkVisualPropertiesRandomizer:
         except rospy.ServiceException, e:
             rospy.logerr("Service call failed: %s" % e)
         self._visuals = res.link_visual_names
-        self._set_link_vis = rospy.ServiceProxy(gazebo_gui_ns + '/set_link_visual_properties', SetLinkVisualProperties)
+        self._parents = res.link_parent_names
+        self._set_link_vis = rospy.ServiceProxy(gazebo_ns + '/set_link_color', SetLinkColor)
 
     def callback(self, event):
         if len(self._visuals) == 0:
             return
-        req = SetLinkVisualPropertiesRequest()
-        req.link_visual_name = np.random.choice(self._visuals)
+        req = SetLinkColorRequest()
+        idx = np.random.choice(len(self._visuals))
+        req.link_visual_name = self._visuals[idx]
+        req.link_parent_name = self._parents[idx]
         color= ColorRGBA(*[np.random.uniform(self._color_range['r']['min'], self._color_range['r']['max']),
                            np.random.uniform(self._color_range['g']['min'], self._color_range['g']['max']),
                            np.random.uniform(self._color_range['b']['min'], self._color_range['b']['max']),

--- a/gazebo_ext_msgs/CMakeLists.txt
+++ b/gazebo_ext_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ add_service_files(DIRECTORY srv FILES
   GetSkyProperties.srv
   SetLinkVisualProperties.srv
   GetLinkVisualProperties.srv
+  SetLinkColor.srv
   SetSurfaceParams.srv
   GetSurfaceParams.srv
   )

--- a/gazebo_ext_msgs/srv/GetVisualNames.srv
+++ b/gazebo_ext_msgs/srv/GetVisualNames.srv
@@ -1,5 +1,6 @@
 string[] link_names
 ---
 string[] link_visual_names
+string[] link_parent_names
 bool success
 string status_message

--- a/gazebo_ext_msgs/srv/SetLinkColor.srv
+++ b/gazebo_ext_msgs/srv/SetLinkColor.srv
@@ -1,0 +1,9 @@
+string link_parent_name
+string link_visual_name
+std_msgs/ColorRGBA ambient
+std_msgs/ColorRGBA diffuse
+std_msgs/ColorRGBA specular
+std_msgs/ColorRGBA emissive
+---
+bool success
+string status_message

--- a/gazebo_physics_plugin/include/gazebo_physics_plugin/gazebo_physics_plugin.h
+++ b/gazebo_physics_plugin/include/gazebo_physics_plugin/gazebo_physics_plugin.h
@@ -16,6 +16,8 @@
 #include <gazebo/physics/physics.hh>
 #undef protected
 #include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/transport/TransportIface.hh>
+#include <gazebo/msgs/msgs.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/Events.hh>
 
@@ -23,6 +25,7 @@
 #include "gazebo_ext_msgs/GetVisualNames.h"
 #include "gazebo_ext_msgs/GetSurfaceParams.h"
 #include "gazebo_ext_msgs/SetSurfaceParams.h"
+#include "gazebo_ext_msgs/SetLinkColor.h"
 
 namespace gazebo
 {
@@ -50,10 +53,17 @@ class GazeboPhysicsPlugin : public WorldPlugin
   /// \brief A mutex to lock access to fields that are used in ROS message callbacks
   private: boost::mutex lock_;
 
+  /// \brief A pointer to the Gazebo node
+  private: transport::NodePtr gzNode;
+
+  /// \brief A pointer to gazebo's ~/visual topic publisher
+  private: transport::PublisherPtr visualPub;
+
   private: ros::ServiceServer get_col_name_srv_;
   private: ros::ServiceServer get_vis_name_srv_;
   private: ros::ServiceServer get_srv_;
   private: ros::ServiceServer set_srv_;
+  private: ros::ServiceServer set_col_srv_;
   private: bool GetCollisionNamesCallback(gazebo_ext_msgs::GetCollisionNames::Request &req,
                                           gazebo_ext_msgs::GetCollisionNames::Response &res);
   private: bool GetVisualNamesCallback(gazebo_ext_msgs::GetVisualNames::Request &req,
@@ -62,6 +72,8 @@ class GazeboPhysicsPlugin : public WorldPlugin
                                          gazebo_ext_msgs::GetSurfaceParams::Response &res);
   private: bool SetSurfaceParamsCallback(gazebo_ext_msgs::SetSurfaceParams::Request &req,
                                          gazebo_ext_msgs::SetSurfaceParams::Response &res);
+  private: bool SetLinkColorCallback(gazebo_ext_msgs::SetLinkColor::Request &req,
+                                     gazebo_ext_msgs::SetLinkColor::Response &res);
 
   // Custom Callback Queue
   private: ros::CallbackQueue queue_;


### PR DESCRIPTION
Hello. Thank you for sharing this repository. 

This pull request is an attempt to fix the problem found on [this issue](https://github.com/neka-nat/gazebo_domain_randomization/issues/3#issue-406507561), where ROS cameras are unable to see the link color changes.

I used the Gazebo Transport Node to publish visual changes into the "~/visual" topic. This code was added into the physics plugin. 

I tested it using a camera integrated into ROS and it worked fine.